### PR TITLE
Update env.sh, os_support.sh and README.md for linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@ Each source code is equal to the original ROM, compilable and editable.
 
 No special requirements (for Windows users). Just launch `assemble.bat` and wait until it's done.
 
-If you have any other OS, try using `assemble.sh` instead. All credits goes to [gb-2312](https://github.com/gb-2312).
+If you have any other OS, try using `sh assemble.sh` in terminal instead. All credits goes to [gb-2312](https://github.com/gb-2312).
+
+**Please do not ~~delete~~ or edit folders `_scripts` and `_install_packages`, unless you know how it works**.
+
+
 
 
 

--- a/_scripts/env.sh
+++ b/_scripts/env.sh
@@ -72,6 +72,8 @@ function check_lua_env() {
                 Linux)
                     echoinfo "This OS is linux!"
 
+                    # install dependency of <readline/readline.h>
+                    Installer readline-devel
                     make linux test
                     Return
                 ;;

--- a/_scripts/env.sh
+++ b/_scripts/env.sh
@@ -3,8 +3,8 @@
 
 # check cc65 compiler
 
-EXEC_PACKAGES_FOLDER=../InstallPackages/bin
-INSTALL_PACKAGES_FOLDER=../InstallPackages/packages
+EXEC_PACKAGES_FOLDER=../_install_packages/bin
+INSTALL_PACKAGES_FOLDER=../_install_packages/packages
 
 CC65_VERSION=2.19
 CC65_INSTALL_PACKAGE_VERSION=cc65-${CC65_VERSION}

--- a/_scripts/os_support.sh
+++ b/_scripts/os_support.sh
@@ -37,7 +37,7 @@ Installer() {
     exit 254
   fi
   # install multiple package(s)
-  while [ "$#" -ge "1" ];do
+  while [ "$#" -ge "1" ]; do
     if [[ -x "/usr/bin/apt-get" ]]; then
       apt-get -y install $1
     elif [[ -x "/usr/bin/yum" ]] ; then

--- a/_scripts/os_support.sh
+++ b/_scripts/os_support.sh
@@ -31,17 +31,23 @@ Return() {
 }
 
 Installer() {
-  if [ $# != 1 ]; then
-    echowarn "Installer only supported for one argument!"
+  # check argument(s) is empty?
+  if [ ! -n "$1" ]; then
+    echowarn "[Installer] missing input argument(s)!"
     exit 254
   fi
-  if [[ -x "/usr/bin/apt-get" ]]; then
-    apt-get -y install $1
-  elif [[ -x "/usr/bin/yum" ]] ; then
-    yum -y install $1
-  else
-    echowarn "No supported package manager installed on system"
-  fi
+  # install multiple package(s)
+  while [ "$#" -ge "1" ];do
+    if [[ -x "/usr/bin/apt-get" ]]; then
+      apt-get -y install $1
+    elif [[ -x "/usr/bin/yum" ]] ; then
+      yum -y install $1
+    else
+      echowarn "No supported package manager installed on system: [$1]"
+    fi
+    # must be shift for $1, otherwise infinite-loop...
+    shift
+  done
 }
 
 today=""

--- a/_scripts/os_support.sh
+++ b/_scripts/os_support.sh
@@ -30,6 +30,20 @@ Return() {
   fi
 }
 
+Installer() {
+  if [ $# != 1 ]; then
+    echowarn "Installer only supported for one argument!"
+    exit 254
+  fi
+  if [[ -x "/usr/bin/apt-get" ]]; then
+    apt-get -y install $1
+  elif [[ -x "/usr/bin/yum" ]] ; then
+    yum -y install $1
+  else
+    echowarn "No supported package manager installed on system"
+  fi
+}
+
 today=""
 month=""
 case ${OS_VERSION} in


### PR DESCRIPTION
Hi cyneprepou4uk:  

Now I fix that during local compilation and installation of lua VM, the dependency of the header file <readline/readline.h> may be missing, execute apt-get/yum -y to install automatic.  

In general, almost all the linux systems have built-in lua VM and no need to install, avoid special streamlined linux systems happens this issue.  

So this PR contains 3 part(s):  

**1):**  
Rename install folder name from `InstallPackages` to `_install_packages` for special-naming.  

**2):**  
Using installer to install `readline-devel` for resolve dependency of the header file <readline/readline.h>.  

**3):**  
Update README.md  

All the above are compiled on `macos` and `centos7`, re-tested and passed!  

Please review this PR, thanks.
