### PR TITLE
Update env.sh to ignore SSL certificate errors

### DIFF
--- a/Battle City/assemble.sh
+++ b/Battle City/assemble.sh
@@ -12,6 +12,11 @@
 NES_OUTPUT_SIMPLE_NAME=battle
 NES_OUTPUT_FILE_SIZE=24592
 
+# navigate to the directory
+BASH_EXEC_DIR=$(dirname $0)
+# goto directory
+cd $BASH_EXEC_DIR
+
 # common function(s)
 source ../_scripts/os_support.sh
 # environment function(s)

--- a/Battle City/assemble.sh
+++ b/Battle City/assemble.sh
@@ -13,9 +13,9 @@ NES_OUTPUT_SIMPLE_NAME=battle
 NES_OUTPUT_FILE_SIZE=24592
 
 # navigate to the directory
-BASH_EXEC_DIR=$(dirname $0)
+BASH_EXEC_DIR=$(dirname "$0")
 # goto directory
-cd $BASH_EXEC_DIR
+cd "${BASH_EXEC_DIR}"
 
 # common function(s)
 source ../_scripts/os_support.sh

--- a/Bugs Bunny Crazy Castle/assemble.sh
+++ b/Bugs Bunny Crazy Castle/assemble.sh
@@ -13,9 +13,9 @@ NES_OUTPUT_SIMPLE_NAME=bbcc
 NES_OUTPUT_FILE_SIZE=98320
 
 # navigate to the directory
-BASH_EXEC_DIR=$(dirname $0)
+BASH_EXEC_DIR=$(dirname "$0")
 # goto directory
-cd $BASH_EXEC_DIR
+cd "${BASH_EXEC_DIR}"
 
 # common function(s)
 source ../_scripts/os_support.sh

--- a/Bugs Bunny Crazy Castle/assemble.sh
+++ b/Bugs Bunny Crazy Castle/assemble.sh
@@ -12,6 +12,11 @@
 NES_OUTPUT_SIMPLE_NAME=bbcc
 NES_OUTPUT_FILE_SIZE=98320
 
+# navigate to the directory
+BASH_EXEC_DIR=$(dirname $0)
+# goto directory
+cd $BASH_EXEC_DIR
+
 # common function(s)
 source ../_scripts/os_support.sh
 # environment function(s)

--- a/Double Dragon II/assemble.sh
+++ b/Double Dragon II/assemble.sh
@@ -13,9 +13,9 @@ NES_OUTPUT_SIMPLE_NAME=dd2
 NES_OUTPUT_FILE_SIZE=262160
 
 # navigate to the directory
-BASH_EXEC_DIR=$(dirname $0)
+BASH_EXEC_DIR=$(dirname "$0")
 # goto directory
-cd $BASH_EXEC_DIR
+cd "${BASH_EXEC_DIR}"
 
 # common function(s)
 source ../_scripts/os_support.sh

--- a/Double Dragon II/assemble.sh
+++ b/Double Dragon II/assemble.sh
@@ -12,6 +12,11 @@
 NES_OUTPUT_SIMPLE_NAME=dd2
 NES_OUTPUT_FILE_SIZE=262160
 
+# navigate to the directory
+BASH_EXEC_DIR=$(dirname $0)
+# goto directory
+cd $BASH_EXEC_DIR
+
 # common function(s)
 source ../_scripts/os_support.sh
 # environment function(s)

--- a/Kunio-kun no Nekketsu Soccer League/assemble.sh
+++ b/Kunio-kun no Nekketsu Soccer League/assemble.sh
@@ -12,6 +12,11 @@
 NES_OUTPUT_SIMPLE_NAME=goal3
 NES_OUTPUT_FILE_SIZE=262160
 
+# navigate to the directory
+BASH_EXEC_DIR=$(dirname $0)
+# goto directory
+cd $BASH_EXEC_DIR
+
 # common function(s)
 source ../_scripts/os_support.sh
 # environment function(s)

--- a/Kunio-kun no Nekketsu Soccer League/assemble.sh
+++ b/Kunio-kun no Nekketsu Soccer League/assemble.sh
@@ -13,9 +13,9 @@ NES_OUTPUT_SIMPLE_NAME=goal3
 NES_OUTPUT_FILE_SIZE=262160
 
 # navigate to the directory
-BASH_EXEC_DIR=$(dirname $0)
+BASH_EXEC_DIR=$(dirname "$0")
 # goto directory
-cd $BASH_EXEC_DIR
+cd "${BASH_EXEC_DIR}"
 
 # common function(s)
 source ../_scripts/os_support.sh

--- a/Mappy/assemble.sh
+++ b/Mappy/assemble.sh
@@ -13,9 +13,9 @@ NES_OUTPUT_SIMPLE_NAME=mappy
 NES_OUTPUT_FILE_SIZE=24592
 
 # navigate to the directory
-BASH_EXEC_DIR=$(dirname $0)
+BASH_EXEC_DIR=$(dirname "$0")
 # goto directory
-cd $BASH_EXEC_DIR
+cd "${BASH_EXEC_DIR}"
 
 # common function(s)
 source ../_scripts/os_support.sh

--- a/Mappy/assemble.sh
+++ b/Mappy/assemble.sh
@@ -12,6 +12,11 @@
 NES_OUTPUT_SIMPLE_NAME=mappy
 NES_OUTPUT_FILE_SIZE=24592
 
+# navigate to the directory
+BASH_EXEC_DIR=$(dirname $0)
+# goto directory
+cd $BASH_EXEC_DIR
+
 # common function(s)
 source ../_scripts/os_support.sh
 # environment function(s)

--- a/Nuts & Milk/assemble.sh
+++ b/Nuts & Milk/assemble.sh
@@ -12,6 +12,11 @@
 NES_OUTPUT_SIMPLE_NAME=nuts
 NES_OUTPUT_FILE_SIZE=24592
 
+# navigate to the directory
+BASH_EXEC_DIR=$(dirname $0)
+# goto directory
+cd $BASH_EXEC_DIR
+
 # common function(s)
 source ../_scripts/os_support.sh
 # environment function(s)

--- a/Nuts & Milk/assemble.sh
+++ b/Nuts & Milk/assemble.sh
@@ -13,9 +13,9 @@ NES_OUTPUT_SIMPLE_NAME=nuts
 NES_OUTPUT_FILE_SIZE=24592
 
 # navigate to the directory
-BASH_EXEC_DIR=$(dirname $0)
+BASH_EXEC_DIR=$(dirname "$0")
 # goto directory
-cd $BASH_EXEC_DIR
+cd "${BASH_EXEC_DIR}"
 
 # common function(s)
 source ../_scripts/os_support.sh

--- a/Solstice/assemble.sh
+++ b/Solstice/assemble.sh
@@ -14,9 +14,9 @@ NES_OUTPUT_SIMPLE_NAME=solstice
 NES_OUTPUT_FILE_SIZE=131088
 
 # navigate to the directory
-BASH_EXEC_DIR=$(dirname $0)
+BASH_EXEC_DIR=$(dirname "$0")
 # goto directory
-cd $BASH_EXEC_DIR
+cd "${BASH_EXEC_DIR}"
 
 # common function(s)
 source ../_scripts/os_support.sh

--- a/Solstice/assemble.sh
+++ b/Solstice/assemble.sh
@@ -13,6 +13,11 @@ NES_IGNORE_COMPILE_ASM_ARRAY=(bank___FF7B_FFF8.asm copy_bank___FF7B_FFF8.asm ban
 NES_OUTPUT_SIMPLE_NAME=solstice
 NES_OUTPUT_FILE_SIZE=131088
 
+# navigate to the directory
+BASH_EXEC_DIR=$(dirname $0)
+# goto directory
+cd $BASH_EXEC_DIR
+
 # common function(s)
 source ../_scripts/os_support.sh
 # environment function(s)

--- a/Son Son/assemble.sh
+++ b/Son Son/assemble.sh
@@ -13,9 +13,9 @@ NES_OUTPUT_SIMPLE_NAME=son
 NES_OUTPUT_FILE_SIZE=40976
 
 # navigate to the directory
-BASH_EXEC_DIR=$(dirname $0)
+BASH_EXEC_DIR=$(dirname "$0")
 # goto directory
-cd $BASH_EXEC_DIR
+cd "${BASH_EXEC_DIR}"
 
 # common function(s)
 source ../_scripts/os_support.sh

--- a/Son Son/assemble.sh
+++ b/Son Son/assemble.sh
@@ -12,6 +12,11 @@
 NES_OUTPUT_SIMPLE_NAME=son
 NES_OUTPUT_FILE_SIZE=40976
 
+# navigate to the directory
+BASH_EXEC_DIR=$(dirname $0)
+# goto directory
+cd $BASH_EXEC_DIR
+
 # common function(s)
 source ../_scripts/os_support.sh
 # environment function(s)

--- a/Street Fighter 3/assemble.sh
+++ b/Street Fighter 3/assemble.sh
@@ -13,9 +13,9 @@ NES_OUTPUT_SIMPLE_NAME=sf3
 NES_OUTPUT_FILE_SIZE=655376
 
 # navigate to the directory
-BASH_EXEC_DIR=$(dirname $0)
+BASH_EXEC_DIR=$(dirname "$0")
 # goto directory
-cd $BASH_EXEC_DIR
+cd "${BASH_EXEC_DIR}"
 
 # common function(s)
 source ../_scripts/os_support.sh

--- a/Street Fighter 3/assemble.sh
+++ b/Street Fighter 3/assemble.sh
@@ -12,6 +12,11 @@
 NES_OUTPUT_SIMPLE_NAME=sf3
 NES_OUTPUT_FILE_SIZE=655376
 
+# navigate to the directory
+BASH_EXEC_DIR=$(dirname $0)
+# goto directory
+cd $BASH_EXEC_DIR
+
 # common function(s)
 source ../_scripts/os_support.sh
 # environment function(s)

--- a/Tecmo World Cup Soccer/assemble.sh
+++ b/Tecmo World Cup Soccer/assemble.sh
@@ -12,6 +12,11 @@
 NES_OUTPUT_SIMPLE_NAME=twcs
 NES_OUTPUT_FILE_SIZE=131088
 
+# navigate to the directory
+BASH_EXEC_DIR=$(dirname $0)
+# goto directory
+cd $BASH_EXEC_DIR
+
 # common function(s)
 source ../_scripts/os_support.sh
 # environment function(s)

--- a/Tecmo World Cup Soccer/assemble.sh
+++ b/Tecmo World Cup Soccer/assemble.sh
@@ -13,9 +13,9 @@ NES_OUTPUT_SIMPLE_NAME=twcs
 NES_OUTPUT_FILE_SIZE=131088
 
 # navigate to the directory
-BASH_EXEC_DIR=$(dirname $0)
+BASH_EXEC_DIR=$(dirname "$0")
 # goto directory
-cd $BASH_EXEC_DIR
+cd "${BASH_EXEC_DIR}"
 
 # common function(s)
 source ../_scripts/os_support.sh

--- a/The Legend of Zelda/assemble.sh
+++ b/The Legend of Zelda/assemble.sh
@@ -13,6 +13,11 @@ NES_IGNORE_COMPILE_ASM_ARRAY=(bank_s1.asm copy_bank_s1.asm bank_s2.asm copy_bank
 NES_OUTPUT_SIMPLE_NAME=zelda
 NES_OUTPUT_FILE_SIZE=131088
 
+# navigate to the directory
+BASH_EXEC_DIR=$(dirname $0)
+# goto directory
+cd $BASH_EXEC_DIR
+
 # common function(s)
 source ../_scripts/os_support.sh
 # environment function(s)

--- a/The Legend of Zelda/assemble.sh
+++ b/The Legend of Zelda/assemble.sh
@@ -14,9 +14,9 @@ NES_OUTPUT_SIMPLE_NAME=zelda
 NES_OUTPUT_FILE_SIZE=131088
 
 # navigate to the directory
-BASH_EXEC_DIR=$(dirname $0)
+BASH_EXEC_DIR=$(dirname "$0")
 # goto directory
-cd $BASH_EXEC_DIR
+cd "${BASH_EXEC_DIR}"
 
 # common function(s)
 source ../_scripts/os_support.sh

--- a/Yie Ar Kung-Fu/assemble.sh
+++ b/Yie Ar Kung-Fu/assemble.sh
@@ -12,6 +12,11 @@
 NES_OUTPUT_SIMPLE_NAME=kungfu
 NES_OUTPUT_FILE_SIZE=24592
 
+# navigate to the directory
+BASH_EXEC_DIR=$(dirname $0)
+# goto directory
+cd $BASH_EXEC_DIR
+
 # common function(s)
 source ../_scripts/os_support.sh
 # environment function(s)

--- a/Yie Ar Kung-Fu/assemble.sh
+++ b/Yie Ar Kung-Fu/assemble.sh
@@ -13,9 +13,9 @@ NES_OUTPUT_SIMPLE_NAME=kungfu
 NES_OUTPUT_FILE_SIZE=24592
 
 # navigate to the directory
-BASH_EXEC_DIR=$(dirname $0)
+BASH_EXEC_DIR=$(dirname "$0")
 # goto directory
-cd $BASH_EXEC_DIR
+cd "${BASH_EXEC_DIR}"
 
 # common function(s)
 source ../_scripts/os_support.sh

--- a/_scripts/env.sh
+++ b/_scripts/env.sh
@@ -29,7 +29,7 @@ function check_cc65_env() {
         if [[ $result = [Yy][Ee][Ss] ]] || [[ $result = [Yy] ]]; then
             currentPwd=`pwd`
             echoerror "Your computer has not install [cc65] compiler, wait a moment and prepare install environment..."
-            curl -o -k ${INSTALL_PACKAGES_FOLDER}/${CC65_INSTALL_PACKAGE_VERSION}.tar.gz "https://codeload.github.com/cc65/cc65/tar.gz/refs/tags/V${CC65_VERSION}"
+            curl -k -o ${INSTALL_PACKAGES_FOLDER}/${CC65_INSTALL_PACKAGE_VERSION}.tar.gz "https://codeload.github.com/cc65/cc65/tar.gz/refs/tags/V${CC65_VERSION}"
             cd ${INSTALL_PACKAGES_FOLDER} && tar xvzf ${CC65_INSTALL_PACKAGE_VERSION}.tar.gz && cd ${CC65_INSTALL_PACKAGE_VERSION}
             Return
 
@@ -58,7 +58,7 @@ function check_lua_env() {
         if [[ $result = [Yy][Ee][Ss] ]] || [[ $result = [Yy] ]]; then
             currentPwd=`pwd`
             echoerror "Your computer has not install [lua] compiler, wait a moment and prepare install environment..."
-            curl -o -k ${INSTALL_PACKAGES_FOLDER}/${LUA_INSTALL_PACKAGE_VERSION}.tar.gz "https://www.lua.org/ftp/${LUA_INSTALL_PACKAGE_VERSION}.tar.gz"
+            curl -k -o ${INSTALL_PACKAGES_FOLDER}/${LUA_INSTALL_PACKAGE_VERSION}.tar.gz "https://www.lua.org/ftp/${LUA_INSTALL_PACKAGE_VERSION}.tar.gz"
             cd ${INSTALL_PACKAGES_FOLDER} && tar xvzf ${LUA_INSTALL_PACKAGE_VERSION}.tar.gz && cd ${LUA_INSTALL_PACKAGE_VERSION}
             Return
 

--- a/_scripts/env.sh
+++ b/_scripts/env.sh
@@ -29,7 +29,7 @@ function check_cc65_env() {
         if [[ $result = [Yy][Ee][Ss] ]] || [[ $result = [Yy] ]]; then
             currentPwd=`pwd`
             echoerror "Your computer has not install [cc65] compiler, wait a moment and prepare install environment..."
-            curl -o ${INSTALL_PACKAGES_FOLDER}/${CC65_INSTALL_PACKAGE_VERSION}.tar.gz "https://codeload.github.com/cc65/cc65/tar.gz/refs/tags/V${CC65_VERSION}"
+            curl -o -k ${INSTALL_PACKAGES_FOLDER}/${CC65_INSTALL_PACKAGE_VERSION}.tar.gz "https://codeload.github.com/cc65/cc65/tar.gz/refs/tags/V${CC65_VERSION}"
             cd ${INSTALL_PACKAGES_FOLDER} && tar xvzf ${CC65_INSTALL_PACKAGE_VERSION}.tar.gz && cd ${CC65_INSTALL_PACKAGE_VERSION}
             Return
 
@@ -58,7 +58,7 @@ function check_lua_env() {
         if [[ $result = [Yy][Ee][Ss] ]] || [[ $result = [Yy] ]]; then
             currentPwd=`pwd`
             echoerror "Your computer has not install [lua] compiler, wait a moment and prepare install environment..."
-            curl -o ${INSTALL_PACKAGES_FOLDER}/${LUA_INSTALL_PACKAGE_VERSION}.tar.gz "https://www.lua.org/ftp/${LUA_INSTALL_PACKAGE_VERSION}.tar.gz"
+            curl -o -k ${INSTALL_PACKAGES_FOLDER}/${LUA_INSTALL_PACKAGE_VERSION}.tar.gz "https://www.lua.org/ftp/${LUA_INSTALL_PACKAGE_VERSION}.tar.gz"
             cd ${INSTALL_PACKAGES_FOLDER} && tar xvzf ${LUA_INSTALL_PACKAGE_VERSION}.tar.gz && cd ${LUA_INSTALL_PACKAGE_VERSION}
             Return
 


### PR DESCRIPTION
Sorry, I only saw this problem yesterday. I have been busy with personal projects recently and have not read the github mail-list.😂

Due to problems such as the expiration of the certificate of the requested remote URL address, the certificate will become invalid.   

Add the flag `-k` to ignore the certificate error, certainly I have already simulation-tested and passed it on macos and centos.

```vim
angel@angels-MacBook-Pro-Work src % man curl | less +/--insecure

       -k, --insecure
              (TLS) By default, every SSL connection curl makes is verified to
              be  secure.  This option allows curl to proceed and operate even
              for server connections otherwise considered insecure.

              The server connection is verified by making  sure  the  server(s)
              certificate  contains  the  right name and verifies successfully
              using the cert store.

              See this online resource for further details:
               https://curl.haxx.se/docs/sslcerts.html

              See also --proxy-insecure and --cacert.
```

Please help to merge this PR, thanks.